### PR TITLE
Add all incompatibilities to fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -36,6 +36,7 @@
   },
   "breaks": {
     "adorn": "*",
+    "connected_block_textures": "*",
     "optifabric": "*",
     "idontlikeoptifabric": "*",
     "sodium": "<=0.1.0",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -41,7 +41,6 @@
     "indrev": "*",
     "lambdabettergrass": "*",
     "optifabric": "*",
-    "idontlikeoptifabric": "*",
     "sodium": "<=0.1.0",
     "hydrogen": "*"
   }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -37,6 +37,7 @@
   "breaks": {
     "adorn": "*",
     "connected_block_textures": "*",
+    "enhancedblockentities": "*",
     "optifabric": "*",
     "idontlikeoptifabric": "*",
     "sodium": "<=0.1.0",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -38,10 +38,10 @@
     "adorn": "*",
     "connected_block_textures": "*",
     "enhancedblockentities": "*",
+    "hydrogen": "*",
     "indrev": "*",
     "lambdabettergrass": "*",
     "optifabric": "*",
-    "sodium": "<=0.1.0",
-    "hydrogen": "*"
+    "sodium": "<=0.1.0"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -38,6 +38,7 @@
     "adorn": "*",
     "connected_block_textures": "*",
     "enhancedblockentities": "*",
+    "indrev": "*",
     "optifabric": "*",
     "idontlikeoptifabric": "*",
     "sodium": "<=0.1.0",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -39,6 +39,7 @@
     "connected_block_textures": "*",
     "enhancedblockentities": "*",
     "indrev": "*",
+    "lambdabettergrass": "*",
     "optifabric": "*",
     "idontlikeoptifabric": "*",
     "sodium": "<=0.1.0",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -35,6 +35,7 @@
     "minecraft": "*"
   },
   "breaks": {
+    "adorn": "*",
     "optifabric": "*",
     "idontlikeoptifabric": "*",
     "sodium": "<=0.1.0",


### PR DESCRIPTION
Adds all known incompatibilities from the Discord's `#known-bugs` channel to fabric.mod.json, to prevent users from accidentally using them together and wondering why DashLoader doesn't work.