### PR TITLE
fabric.mod.json - Switch to LGPLv3.0 from LGPLv2.1

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -12,7 +12,7 @@
     "issues": "https://github.com/alphaqu/DashLoader/issues",
     "sources": "https://github.com/alphaqu/DashLoader"
   },
-  "license": "LGPLv3.0",
+  "license": "LGPL-3.0-only",
   "icon": "assets/dashloader/textures/icon.png",
   "environment": "client",
   "accessWidener": "dashloader.accesswidener",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -12,7 +12,7 @@
     "issues": "https://github.com/alphaqu/DashLoader/issues",
     "sources": "https://github.com/alphaqu/DashLoader"
   },
-  "license": "LGPLv2.1",
+  "license": "LGPLv3.0",
   "icon": "assets/dashloader/textures/icon.png",
   "environment": "client",
   "accessWidener": "dashloader.accesswidener",


### PR DESCRIPTION
Missed in https://github.com/alphaqu/DashLoader/commit/b4caf02a636c54e6da6055afd2b3fc56e442d193
Or should it be LGPLv3?
I checked a few mods and this differs greatly
![Screenshot from 2021-07-18 20-33-14](https://user-images.githubusercontent.com/43277609/126078536-602689ca-67ba-45e6-95e8-31e19c10c6a2.png)
![Screenshot from 2021-07-18 20-33-39](https://user-images.githubusercontent.com/43277609/126078537-593a09f8-336d-41ae-9083-f3c9c02e4e41.png)
